### PR TITLE
ORBAT - Prepend role description to player name in Orbat tab

### DIFF
--- a/addons/orbat/functions/fnc_createBriefingPage.sqf
+++ b/addons/orbat/functions/fnc_createBriefingPage.sqf
@@ -261,21 +261,21 @@ _fnc_processOrbatTrackerBriefingRawData = {
                         };
                     };
 
-                    private _memberRole = "";
-                    private _memberPrep01 = roleDescription _x;
-                    if (["@",_memberPrep01] call BIS_fnc_inString) then {
-                        _memberRole = (_memberPrep01 splitString "@") select 0;
+                    //Add role description if present, and account for CBA role description format
+                    private _unitRole = roleDescription _x;
+                    if (_unitRole regexFind ["@"] isNotEqualTo []) then {
+                        _unitRole = (_unitRole splitString "@") select 0;
                     } else {
-                        if (isNil _memberRole || {_memberRole isEqualTo ""}) then {
-                            _memberRole = "Member";
-                            if (_x == leader group _x) then {_memberRole = "Leader";};
+                        if (isNil _unitRole || {_unitRole isEqualTo ""}) then {
+                            _unitRole = "Member";
+                            if (_x == leader group _x) then {_unitRole = "Leader";};
                         };
                     };
-                    if (_memberRole isNotEqualTo "") then {
-                        _memberRole = _memberRole + " - ";
+                    if (_unitRole isNotEqualTo "") then {
+                        _unitRole = _unitRole + " - ";
                     };
 
-                    private _unitText = format["      %4<img image='%1' height='16'></img> %2%3 (", _unitImg, _memberRole, name _x, _indent];
+                    private _unitText = format["      %4<img image='%1' height='16'></img> %2%3 (", _unitImg, _unitRole, name _x, _indent];
 
                     if (primaryWeapon _x != "") then {
                         (primaryWeaponItems _x) params ["_muzzel", "", "_optic", "_bipod"];

--- a/addons/orbat/functions/fnc_createBriefingPage.sqf
+++ b/addons/orbat/functions/fnc_createBriefingPage.sqf
@@ -261,7 +261,21 @@ _fnc_processOrbatTrackerBriefingRawData = {
                         };
                     };
 
-                    private _unitText = format["      %3<img image='%1' height='16'></img> %2 (", _unitImg, name _x, _indent];
+                    private _memberRole = "";
+                    private _memberPrep01 = roleDescription _x;
+                    if (["@",_memberPrep01] call BIS_fnc_inString) then {
+                        _memberRole = (_memberPrep01 splitString "@") select 0;
+                    } else {
+                        if (isNil _memberRole || {_memberRole isEqualTo ""}) then {
+                            _memberRole = "Member";
+                            if (_x == leader group _x) then {_memberRole = "Leader";};
+                        };
+                    };
+                    if (_memberRole isNotEqualTo "") then {
+                        _memberRole = _memberRole + " - ";
+                    };
+
+                    private _unitText = format["      %4<img image='%1' height='16'></img> %2%3 (", _unitImg, _memberRole, name _x, _indent];
 
                     if (primaryWeapon _x != "") then {
                         (primaryWeaponItems _x) params ["_muzzel", "", "_optic", "_bipod"];


### PR DESCRIPTION
**When merged this pull request will:**
Prepend the player's CBA role description to their name in the Orbat tab in the briefing.
If no CBA role description is given it will do `Leader - PlayerName` for the group leader and `Member - PlayerName` for the remaining members.

Another framework I used did this and I find it makes it a lot easier to figure out who has what role, instead of looking at the listed weapons and guessing what their role could be.

![caa2f185fc9095b16702598d413e6f6c](https://user-images.githubusercontent.com/15274778/155879345-9b3138d3-d4fc-4c8b-8307-53db0b80d0a8.png)
