### PR TITLE
Spectator - Fix bad comparison

### DIFF
--- a/addons/spectator/functions/fnc_controlSetPicture.sqf
+++ b/addons/spectator/functions/fnc_controlSetPicture.sqf
@@ -16,14 +16,14 @@
  *
  * Public: No
  */
-params ["_control","_picturePath","_color"];
+params ["_control","_picturePath",["_color", [0.70, 0.60, 0.00, 1.00], [[]]]];
 disableSerialization;
 private _image = (_control controlsGroupCtrl 1);
 if (_picturePath != "" && {_control getVariable [QGVAR(lastImage),""] != _picturePath}) then {
     _image ctrlSetText _picturePath;
     _control setVariable [QGVAR(lastImage),_picturePath];
 };
-if (_control getVariable [QGVAR(lastColor),""] != _color) then {
+if (_control getVariable [QGVAR(lastColor),""] isNotEqualTo _color) then {
     _image ctrlSetTextColor _color;
     _control setVariable [QGVAR(lastColor),_color];
 };

--- a/addons/spectator/functions/fnc_controlSetText.sqf
+++ b/addons/spectator/functions/fnc_controlSetText.sqf
@@ -13,7 +13,7 @@
  * nil
  *
  * Example:
- * [_control,"mytext",[1,1,1,1],false] call tmf_spectator_fnc_controlSetPicture
+ * [_control,"mytext",[1,1,1,1],false] call tmf_spectator_fnc_controlSetText
  *
  * Public: No
  */


### PR DESCRIPTION
**When merged this pull request will:**
- Fix bad comparison in tmf_spectator_fnc_controlSetPicture and force variable to be array type
- fix example in header of tmf_spectator_fnc_controlSetText