### PR TITLE
Autotest - Flip autotest source priority

### DIFF
--- a/addons/autotest/functions/fnc_autotest_author_attributeLoad.sqf
+++ b/addons/autotest/functions/fnc_autotest_author_attributeLoad.sqf
@@ -2,7 +2,7 @@
 
 private _value = getMissionConfigValue "author";
 
-if (isNil "_value") then {
+if (isNil "_value" || {!(_value isEqualType "")}) then {
     _value = "Scenario" get3DENMissionAttribute "Author";
 };
 

--- a/addons/autotest/functions/fnc_autotest_author_attributeLoad.sqf
+++ b/addons/autotest/functions/fnc_autotest_author_attributeLoad.sqf
@@ -1,9 +1,9 @@
 #include "\x\tmf\addons\autotest\script_component.hpp"
 
-private _value = "Scenario" get3DENMissionAttribute "Author";
+private _value = getMissionConfigValue "author";
 
-if (_value == "") then {
-    _value = getMissionConfigValue "author";
+if (isNil "_value") then {
+    _value = "Scenario" get3DENMissionAttribute "Author";
 };
 
 (_this controlsGroupCtrl 100) ctrlSetText _value;

--- a/addons/autotest/functions/fnc_autotest_missionName_attributeLoad.sqf
+++ b/addons/autotest/functions/fnc_autotest_missionName_attributeLoad.sqf
@@ -2,7 +2,7 @@
 
 private _value = getMissionConfigValue "onLoadName";
 
-if (isNil "_value") then {
+if (isNil "_value" || {!(_value isEqualType "")}) then {
     _value = "Scenario" get3DENMissionAttribute "IntelBriefingName";
 };
 

--- a/addons/autotest/functions/fnc_autotest_missionName_attributeLoad.sqf
+++ b/addons/autotest/functions/fnc_autotest_missionName_attributeLoad.sqf
@@ -1,9 +1,9 @@
 #include "\x\tmf\addons\autotest\script_component.hpp"
 
-private _value = "Scenario" get3DENMissionAttribute "IntelBriefingName";
+private _value = getMissionConfigValue "onLoadName";
 
-if (_value == "") then {
-    _value = getMissionConfigValue "onLoadName";
+if (isNil "_value") then {
+    _value = "Scenario" get3DENMissionAttribute "IntelBriefingName";
 };
 
 (_this controlsGroupCtrl 100) ctrlSetText _value;

--- a/addons/autotest/functions/fnc_autotest_missionSummary_attributeLoad.sqf
+++ b/addons/autotest/functions/fnc_autotest_missionSummary_attributeLoad.sqf
@@ -2,7 +2,7 @@
 
 private _value = getMissionConfigValue "overviewText";
 
-if (isNil "_value") then {
+if (isNil "_value" || {!(_value isEqualType "")}) then {
     _value = "Multiplayer" get3DENMissionAttribute "IntelOverviewText";
 };
 

--- a/addons/autotest/functions/fnc_autotest_missionSummary_attributeLoad.sqf
+++ b/addons/autotest/functions/fnc_autotest_missionSummary_attributeLoad.sqf
@@ -1,9 +1,9 @@
 #include "\x\tmf\addons\autotest\script_component.hpp"
 
-private _value = "Multiplayer" get3DENMissionAttribute "IntelOverviewText";
+private _value = getMissionConfigValue "overviewText";
 
-if (_value == "") then {
-    _value = getMissionConfigValue "overviewText";
+if (isNil "_value") then {
+    _value = "Multiplayer" get3DENMissionAttribute "IntelOverviewText";
 };
 
 (_this controlsGroupCtrl 100) ctrlSetText _value;


### PR DESCRIPTION
**When merged this pull request will:**
- description.ext should come first as it takes priority in game, plus getMissionConfigValue returns nil if there is no entry, so it's better to check that first and then if nil set the value to something that always returns a string