### PR TITLE
Autotest - Add one more validation check to mission summary autotest

### DIFF
--- a/.hemtt/project.toml
+++ b/.hemtt/project.toml
@@ -18,6 +18,6 @@ exclude = [
 [version]
 major = 1
 minor = 0
-patch = 1
-build = 2
+patch = 2
+build = 3
 git_hash = 8

--- a/addons/autotest/functions/fnc_autotest_missionSummary_attributeLoad.sqf
+++ b/addons/autotest/functions/fnc_autotest_missionSummary_attributeLoad.sqf
@@ -2,7 +2,13 @@
 
 private _value = getMissionConfigValue "overviewText";
 
-if (isNil "_value" || {!(_value isEqualType "")} || {_value == "*** Insert mission description here. ***"} || {_value == ""}) then {
+if (
+    isNil "_value"
+    || {!(_value isEqualType "")}
+    || {_value == "*** Insert mission description here. ***"}
+    || {_value == "Scenario" get3DENMissionAttribute "OverviewText"}
+    || {_value == ""}
+) then {
     _value = "Multiplayer" get3DENMissionAttribute "IntelOverviewText";
 };
 


### PR DESCRIPTION
**When merged this pull request will:**
- Title
- `getMissionConfigValue "overviewText"` has stupid returns